### PR TITLE
{topost} RDMA/hns: Bugfix for asynchronous event process

### DIFF
--- a/drivers/infiniband/hw/hns/hns_roce_hw_v2.c
+++ b/drivers/infiniband/hw/hns/hns_roce_hw_v2.c
@@ -4622,7 +4622,6 @@ static int hns_roce_v2_aeq_int(struct hns_roce_dev *hr_dev,
 		switch (event_type) {
 		case HNS_ROCE_EVENT_TYPE_PATH_MIG:
 		case HNS_ROCE_EVENT_TYPE_PATH_MIG_FAILED:
-			break;
 		case HNS_ROCE_EVENT_TYPE_COMM_EST:
 		case HNS_ROCE_EVENT_TYPE_SQ_DRAINED:
 		case HNS_ROCE_EVENT_TYPE_WQ_CATAS_ERROR:


### PR DESCRIPTION
According to IB protocol, an event handler should be notified
while path migrated and communication established occured,
this patch fixes it.

Reported-by: Lijun Ou <oulijun@huawei.com>
Fixes: a5073d6054f7 ("RDMA/hns: Add eq support of hip08")
Signed-off-by: Yixian Liu <liuyixian@huawei.com>