### PR TITLE
crypto/hisilicon/qm: Align the requested dma pages

### DIFF
--- a/drivers/crypto/hisilicon/qm.c
+++ b/drivers/crypto/hisilicon/qm.c
@@ -1034,7 +1034,8 @@ struct hisi_qp *hisi_qm_create_qp(struct hisi_qm *qm, u8 alg_type)
 	/* allocate qp dma memory, uacce uses dus region for this */
 	if (qm->use_dma_api) {
 		qp->qdma.size = qm->sqe_size * QM_Q_DEPTH +
-				sizeof(struct cqe) * QM_Q_DEPTH,
+				sizeof(struct cqe) * QM_Q_DEPTH;
+		qp->qdma.size = PAGE_ALIGN(qp->qdma.size);
 		qp->qdma.va = dma_alloc_coherent(dev, qp->qdma.size,
 						 &qp->qdma.dma,
 						 GFP_KERNEL | __GFP_ZERO);


### PR DESCRIPTION
1. fix typo, It is better to use semicolon althogh comma operator
   will not produce an error.
2. determine if the requested dma memory size is an integer of pages,
   adapt to different page size scenarios(4k/64k).

Signed-off-by: Shukun <tanshukun1@huawei.com>